### PR TITLE
Fix typo, incorrectly inserted text

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: workshop      # DON'T CHANGE THIS.
 carpentry: "dc"    # what kind of Carpentry (must be either "lc" or "dc" or "swc").  
                       # Be sure to update the Carpentry type in _config.yml as well.  
-venue: "Univerrsity of the Western Cape"        # brief name of host site without address (e.g., "Euphoric State University")
+venue: "University of the Western Cape"        # brief name of host site without address (e.g., "Euphoric State University")
 address: "SANBI Training Room, Level 5,Life Sciences Building"      # full street address of workshop (e.g., "Room A, 123 Forth Street, Blimingen, Euphoria")
 country: "za"      # lowercase two-letter ISO country code such as "fr" (see https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes)
 language: "en"     # lowercase two-letter ISO language code such as "fr" (see https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
@@ -95,7 +95,7 @@ workshop is only open to people from a particular institution.
 {% if page.carpentry == "swc" %}
 {% include sc/who.html %}
 {% elsif page.carpentry == "dc" %}
-{% include dc/The course is aimed at graduate students and other researchers. You don't need to have any previous knowledge of the tools that will be presented at the workshop.html %}
+{% include dc/who.html %}
 {% elsif page.carpentry == "lc" %}
 {% include lc/who.html %}
 {% endif %}


### PR DESCRIPTION
Fixed typo in spelling of University, removed the text inserted around the `{% include dc/who.html %}`.